### PR TITLE
fix: go.mod min version 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Flokey82/go_gens
+
+go 1.18


### PR DESCRIPTION
Even with genworldvoronoi go.mod set to 1.18 Go seems determined to use 1.16 for this. Figured this lib may as well declare a min Go version 

```
> go build -o server cmd/server/main.go
# github.com/Flokey82/go_gens/utils
../../../../pkg/mod/github.com/!flokey82/go_gens@v0.0.0-20230205151702-467835c3d5bf/utils/utils.go:113:2: embedding interface element int | int64 | float64 requires go1.18 or later (-lang was set to go1.16; check go.mod)
../../../../pkg/mod/github.com/!flokey82/go_gens@v0.0.0-20230205151702-467835c3d5bf/utils/utils.go:117:13: type parameter requires go1.18 or later (-lang was set to go1.16; check go.mod)
../../../../pkg/mod/github.com/!flokey82/go_gens@v0.0.0-20230205151702-467835c3d5bf/utils/utils.go:119:10: cannot use 0 (untyped int constant) as V value in return statement
../../../../pkg/mod/github.com/!flokey82/go_gens@v0.0.0-20230205151702-467835c3d5bf/utils/utils.go:124:6: invalid operation: v < min (type parameter V is not comparable with <)
../../../../pkg/mod/github.com/!flokey82/go_gens@v0.0.0-20230205151702-467835c3d5bf/utils/utils.go:127:6: invalid operation: v > max (type parameter V is not comparable with >)
```